### PR TITLE
Add Codex macOS parity review and ReAcT implementation plan

### DIFF
--- a/docs/reports/codex-macos-parity-review-2026-02-08.md
+++ b/docs/reports/codex-macos-parity-review-2026-02-08.md
@@ -99,7 +99,7 @@ From the Codex changelog page, the macOS app entries within the past 7 days:
 1. **Source‑of‑truth mapping**
    - Create a parity checklist that maps macOS app features to repo modules (swarm orchestration, CLI command runner, automation/skills, Git tooling).
 2. **Environment parity harness**
-   - Add a shell‑compatibility test suite to run representative commands (pipes, redirects, regex). Use `bash -lc` today; add a macOS `zsh` profile option and compare outputs.
+   - Add a shell-compatibility test suite to run representative commands (pipes, redirects, regex, path resolution). Use `bash -lc` today; add a macOS `zsh` profile option and compare outputs.
 3. **Swarm execution profile**
    - Introduce a “macOS local” swarm profile that:
      - Uses local filesystem paths and process execution constraints.


### PR DESCRIPTION
### Motivation
- Capture an evidence-based parity review between the official Codex macOS app (docs + recent changelog) and the Codex‑Synaptic repo to identify gaps in local execution, swarm behavior, and UI-driven features. 
- Surface concrete environment compatibility checks (pipelines, redirection, regex, shell differences) so the repo can match the app’s Local mode semantics. 
- Propose a ReAcT-style, step-by-step implementation plan for closing parity gaps (mid-turn steering, attachments, macOS swarm profile, tests, docs). 

### Description
- Added a new report `docs/reports/codex-macos-parity-review-2026-02-08.md` that summarizes official sources reviewed and lists changelog items from 2026-02-02 through 2026-02-05. 
- Mapped app capabilities to repo subsystems (swarm, CLI, automations, skills, Git/worktree) and recorded actionable parity checks for shell semantics (e.g., `find . -type f | grep -E 'pattern'`, redirection, and regex tools). 
- Included repo evidence showing the CLI local executor uses `bash -lc` (see `src/cli/codex-passthrough.ts`, `executeLocalCommand`) to demonstrate current pipeline/redirection compatibility. 
- Embedded a ReAcT (Reason → Act → Observe → Update) framework and a 9-step technical implementation plan covering parity checklist, environment parity harness, macOS swarm profile, mid-turn steering, attachment support, worktree/Git alignment, docs, validation, and release readiness. 

### Testing
- No automated tests were required or run for this change because it is documentation-only and contains no runtime code modifications. 
- CI/lint/test suites were not executed as part of this PR since the patch only adds a report under `docs/reports/`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69888fdda3c08333b7bcdd5e63f95272)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 5 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fclduab11%2Fcodex-synaptic%2Fpull%2F39&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->